### PR TITLE
Error context

### DIFF
--- a/src/quorum.rs
+++ b/src/quorum.rs
@@ -1,5 +1,5 @@
 use crate::Generate;
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use ecies::utils::generate_keypair;
 use pem::{encode, parse, Pem};
 use rand::rngs::OsRng;
@@ -42,10 +42,10 @@ pub fn generate(args: &Generate) -> Result<()> {
         let encoded_pem = encode(&sk_pem);
 
         if let Some(path) = &args.out {
-            fs::write(
-                Path::new(&path).join(format!("quorum_share_{}.priv", i)),
-                encoded_pem,
-            )?;
+            let share_name = format!("quorum_share_{}.priv", i);
+            fs::write(Path::new(&path).join(&share_name), encoded_pem).with_context(|| {
+                format!("Failed to write share file {} to {}", &share_name, path)
+            })?;
         } else {
             print!("{}", encoded_pem);
         }
@@ -59,7 +59,8 @@ pub fn generate(args: &Generate) -> Result<()> {
     let encoded_pem = encode(&pk_pem);
 
     if let Some(path) = &args.out {
-        fs::write(Path::new(&path).join("quorum.pub"), encoded_pem)?;
+        fs::write(Path::new(&path).join("quorum.pub"), encoded_pem)
+            .with_context(|| format!("Failed to write public key to {}", path))?;
     } else {
         print!("{}", encoded_pem);
     }
@@ -67,7 +68,7 @@ pub fn generate(args: &Generate) -> Result<()> {
     Ok(())
 }
 
-pub fn recover_secret(share_paths: Vec<String>, threshold: u8) -> Result<[u8; 32]> {
+pub fn recover_secret(share_paths: &Vec<String>, threshold: u8) -> Result<[u8; 32]> {
     if share_paths.is_empty() {
         bail!("You must provide at least one share");
     }
@@ -87,14 +88,22 @@ pub fn recover_secret(share_paths: Vec<String>, threshold: u8) -> Result<[u8; 32
     // All shares must have this same ID to prevent accidentally
     // combining shares that do not match.
     let mut quorum_id = [0u8; QUORUM_ID_SIZE];
-    let first_path = share_paths.first().unwrap();
-    let file = fs::read(first_path)?;
-    let pem = parse(file)?;
+    let first_path = share_paths.first().unwrap(); // safe, empty check above
+
+    let file = fs::read(first_path)
+        .with_context(|| format!("Failed to read share from: {}", first_path))?;
+
+    let pem =
+        parse(file).with_context(|| format!("Failed to parse PEM file from: {}", first_path))?;
+
     quorum_id.copy_from_slice(&pem.contents[pem.contents.len() - QUORUM_ID_SIZE..]);
 
     for path in share_paths {
-        let file = fs::read(path)?;
-        let mut pem = parse(file)?;
+        let file =
+            fs::read(&path).with_context(|| format!("Failed to read share from: {}", &path))?;
+
+        let mut pem =
+            parse(file).with_context(|| format!("Failed to parse PEM share from: {}", &path))?;
 
         let mut share_quorum_id = [0u8; QUORUM_ID_SIZE];
         share_quorum_id.copy_from_slice(&pem.contents[pem.contents.len() - QUORUM_ID_SIZE..]);
@@ -106,7 +115,7 @@ pub fn recover_secret(share_paths: Vec<String>, threshold: u8) -> Result<[u8; 32
         pem.contents.truncate(pem.contents.len() - QUORUM_ID_SIZE);
 
         let share = Share::try_from(pem.contents.as_slice())
-            .map_err(|e| anyhow!("Failed to convert PEM-encoded share to Share: {:?}", e))?;
+            .map_err(|e| anyhow!("Failed to convert PEM to Share: {}", e))?;
 
         shares.push(share);
     }


### PR DESCRIPTION
Added error context handling, which provides more useful error stacks to the user such as:

```
Error: Failed to recover secret

Caused by:
    0: Failed to read share from: /dev/nullll
    1: No such file or directory (os error 2)
```